### PR TITLE
.NET 8 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
           source-url: https://nuget.pkg.github.com/${{ github.actor }}/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -41,7 +41,7 @@ jobs:
       - name: Setup .NET Core SDKs
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use .NET Core SDK
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
           source-url: https://api.nuget.org/v3/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.NUGET_AUTH_TOKEN}}

--- a/.github/workflows/test-code.yml
+++ b/.github/workflows/test-code.yml
@@ -21,8 +21,8 @@ jobs:
           dotnet-version: |
             2.1.x
             3.1.x
-            5.0.x
             6.0.x
+            8.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build solution [Debug]

--- a/.github/workflows/test-documentation.yml
+++ b/.github/workflows/test-documentation.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup .NET Core SDKs
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
         with:

--- a/EPPlus/Compatibility/ImageCompat.cs
+++ b/EPPlus/Compatibility/ImageCompat.cs
@@ -8,6 +8,9 @@ using System.Text;
 
 namespace OfficeOpenXml.Compatibility
 {
+#if NET6_0_OR_GREATER
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     internal class ImageCompat
     {
         internal static byte[] GetImageAsByteArray(Image image)

--- a/EPPlus/Drawing/ExcelDrawingBase.cs
+++ b/EPPlus/Drawing/ExcelDrawingBase.cs
@@ -349,7 +349,9 @@ namespace OfficeOpenXml.Drawing
             //}
             else if (node.SelectSingleNode("xdr:pic", drawings.NameSpaceManager) != null)
             {
+#pragma warning disable CA1416 // Validate platform compatibility
                 return new ExcelPicture(drawings, node);
+#pragma warning restore CA1416 // Validate platform compatibility
             }
             else if (node.SelectSingleNode("xdr:graphicFrame", drawings.NameSpaceManager) != null)
             {

--- a/EPPlus/Drawing/ExcelDrawings.cs
+++ b/EPPlus/Drawing/ExcelDrawings.cs
@@ -304,6 +304,9 @@ namespace OfficeOpenXml.Drawing
             /// <param name="Name"></param>
             /// <param name="image">An image. Allways saved in then JPeg format</param>
             /// <returns></returns>
+#if NET6_0_OR_GREATER
+            [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
             public ExcelPicture AddPicture(string Name, Image image)
             {
                return AddPicture(Name, image, null);
@@ -315,6 +318,9 @@ namespace OfficeOpenXml.Drawing
             /// <param name="image">An image. Allways saved in then JPeg format</param>
             /// <param name="Hyperlink">Picture Hyperlink</param>
             /// <returns></returns>
+#if NET6_0_OR_GREATER
+            [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
             public ExcelPicture AddPicture(string Name, Image image, Uri Hyperlink)
             {
                 if (image != null)
@@ -339,6 +345,9 @@ namespace OfficeOpenXml.Drawing
             /// <param name="Name"></param>
             /// <param name="ImageFile">The image file</param>
             /// <returns></returns>
+#if NET6_0_OR_GREATER
+            [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
             public ExcelPicture AddPicture(string Name, FileInfo ImageFile)
             {
                return AddPicture(Name, ImageFile, null);
@@ -350,6 +359,9 @@ namespace OfficeOpenXml.Drawing
             /// <param name="ImageFile">The image file</param>
             /// <param name="Hyperlink">Picture Hyperlink</param>
             /// <returns></returns>
+#if NET6_0_OR_GREATER
+            [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
             public ExcelPicture AddPicture(string Name, FileInfo ImageFile, Uri Hyperlink)
             {
                 if (Worksheet is ExcelChartsheet && _drawings.Count > 0)

--- a/EPPlus/Drawing/ExcelPicture.cs
+++ b/EPPlus/Drawing/ExcelPicture.cs
@@ -46,6 +46,9 @@ namespace OfficeOpenXml.Drawing
     /// <summary>
     /// An image object
     /// </summary>
+#if NET6_0_OR_GREATER
+    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
     public sealed class ExcelPicture : ExcelDrawing
     {
         #region "Constructors"

--- a/EPPlus/Drawing/Vml/ExcelVmlDrawingPicture.cs
+++ b/EPPlus/Drawing/Vml/ExcelVmlDrawingPicture.cs
@@ -133,6 +133,9 @@ namespace OfficeOpenXml.Drawing.Vml
         /// <summary>
         /// The image
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public Image Image
         {
             get

--- a/EPPlus/EPPlus.MultiTarget.csproj
+++ b/EPPlus/EPPlus.MultiTarget.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp3.1;net35;net40</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;netcoreapp3.1;net35;net40;net6.0;net8.0</TargetFrameworks>
     <VersionPrefix>4.5.4-preview</VersionPrefix>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	<PackageIcon>icon.jpg</PackageIcon>
@@ -37,9 +37,10 @@
     <PackageLicenseFile>lgpl-3.0.txt</PackageLicenseFile>
 	<NoWarn>$(NoWarn);CS1591;CS1572</NoWarn>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<WarningsAsErrors>CA1416</WarningsAsErrors>
   </PropertyGroup>
  
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' OR '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net8.0'">
     <DefineConstants>Core</DefineConstants>
   </PropertyGroup>
 
@@ -77,6 +78,16 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.32" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.3" />
     <PackageReference Include="System.Security.Cryptography.Pkcs" Version="4.7.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="6.0.4" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
+    <PackageReference Include="System.Security.Cryptography.Pkcs" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="" />

--- a/EPPlus/ExcelBackgroundImage.cs
+++ b/EPPlus/ExcelBackgroundImage.cs
@@ -66,6 +66,9 @@ namespace OfficeOpenXml
         /// The background image of the worksheet. 
         /// The image will be saved internally as a jpg.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public Image Image
         {
             get
@@ -105,6 +108,9 @@ namespace OfficeOpenXml
         /// The image file will be saved as a blob, so make sure Excel supports the image format.
         /// </summary>
         /// <param name="PictureFile">The image file.</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void SetFromFile(FileInfo PictureFile)
         {
             DeletePrevImage();
@@ -142,6 +148,9 @@ namespace OfficeOpenXml
             var rel = _workSheet.Part.CreateRelationship(imageURI, Packaging.TargetMode.Internal, ExcelPackage.schemaRelationships + "/image");
             SetXmlNodeString(BACKGROUNDPIC_PATH, rel.Id);
         }
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         private void DeletePrevImage()
         {
             var relID = GetXmlNodeString(BACKGROUNDPIC_PATH);

--- a/EPPlus/ExcelColumn.cs
+++ b/EPPlus/ExcelColumn.cs
@@ -274,6 +274,9 @@ namespace OfficeOpenXml
         /// Note: Cells containing formulas are ignored since EPPlus don't have a calculation engine.
         ///       Wrapped and merged cells are also ignored.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFit()
         {
             _worksheet.Cells[1, _columnMin, ExcelPackage.MaxRows, _columnMax].AutoFitColumns();
@@ -285,6 +288,9 @@ namespace OfficeOpenXml
         ///       Wrapped and merged cells are also ignored.
         /// </summary>
         /// <param name="MinimumWidth">Minimum column width</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFit(double MinimumWidth)
         {
             _worksheet.Cells[1, _columnMin, ExcelPackage.MaxRows, _columnMax].AutoFitColumns(MinimumWidth);
@@ -297,6 +303,9 @@ namespace OfficeOpenXml
         /// </summary>
         /// <param name="MinimumWidth">Minimum column width</param>
         /// <param name="MaximumWidth">Maximum column width</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFit(double MinimumWidth, double MaximumWidth)
         {
             _worksheet.Cells[1, _columnMin, ExcelPackage.MaxRows, _columnMax].AutoFitColumns(MinimumWidth, MaximumWidth);

--- a/EPPlus/ExcelHeaderFooter.cs
+++ b/EPPlus/ExcelHeaderFooter.cs
@@ -122,6 +122,9 @@ namespace OfficeOpenXml
         /// </summary>
         /// <param name="Picture">The image object containing the Picture</param>
         /// <param name="Alignment">Alignment. The image object will be inserted at the end of the Text.</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public ExcelVmlDrawingPicture InsertPicture(Image Picture, PictureAlignment Alignment)
         {
             string id = ValidateImage(Alignment);
@@ -144,6 +147,9 @@ namespace OfficeOpenXml
         /// </summary>
         /// <param name="PictureFile">The image object containing the Picture</param>
         /// <param name="Alignment">Alignment. The image object will be inserted at the end of the Text.</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public ExcelVmlDrawingPicture InsertPicture(FileInfo PictureFile, PictureAlignment Alignment)
         {
             string id = ValidateImage(Alignment);
@@ -176,6 +182,9 @@ namespace OfficeOpenXml
             return AddImage(Picture, id, ii);
         }
 
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         private ExcelVmlDrawingPicture AddImage(Image Picture, string id, ExcelPackage.ImageInfo ii)
         {
             double width = Picture.Width * 72 / Picture.HorizontalResolution,      //Pixel --> Points

--- a/EPPlus/ExcelRangeBase.cs
+++ b/EPPlus/ExcelRangeBase.cs
@@ -771,6 +771,9 @@ namespace OfficeOpenXml
         /// Note: Cells containing formulas must be calculated before autofit is called.
         /// Wrapped and merged cells are also ignored.
         /// </summary>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFitColumns()
         {
             AutoFitColumns(_worksheet.DefaultColWidth);
@@ -783,6 +786,9 @@ namespace OfficeOpenXml
         /// </summary>
         /// <remarks>This method will not work if you run in an environment that does not support GDI</remarks>
         /// <param name="MinimumWidth">Minimum column width</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFitColumns(double MinimumWidth)
         {
             AutoFitColumns(MinimumWidth, double.MaxValue);
@@ -796,6 +802,9 @@ namespace OfficeOpenXml
         /// </summary>
         /// <param name="MinimumWidth">Minimum column width</param>
         /// <param name="MaximumWidth">Maximum column width</param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void AutoFitColumns(double MinimumWidth, double MaximumWidth)
         {
             if (_worksheet.Dimension == null)

--- a/EPPlus/ExcelWorksheets.cs
+++ b/EPPlus/ExcelWorksheets.cs
@@ -249,7 +249,9 @@ namespace OfficeOpenXml
                 //CopyRelationShips(Copy, added);
                 if (Copy.Drawings.Count > 0)
                 {
+#pragma warning disable CA1416 // Validate platform compatibility
                     CopyDrawing(Copy, added);
+#pragma warning restore CA1416 // Validate platform compatibility
                 }
                 if (Copy.Tables.Count > 0)
                 {
@@ -661,6 +663,9 @@ namespace OfficeOpenXml
 
             e.SetAttribute("id", ExcelPackage.schemaRelationships, newVmlRel.Id);
         }
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         private void CopyDrawing(ExcelWorksheet Copy, ExcelWorksheet workSheet/*, PackageRelationship r*/)
         {
             

--- a/EPPlus/FormulaParsing/CalculateExtentions.cs
+++ b/EPPlus/FormulaParsing/CalculateExtentions.cs
@@ -157,7 +157,7 @@ namespace OfficeOpenXml
                 }
                 catch (FormatException fe)
                 {
-                    throw (fe);
+                    throw;
                 }
                 catch
                 {

--- a/EPPlus/Style/ExcelFont.cs
+++ b/EPPlus/Style/ExcelFont.cs
@@ -213,6 +213,9 @@ namespace OfficeOpenXml.Style
         /// Set the font from a Font object
         /// </summary>
         /// <param name="Font"></param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void SetFromFont(Font Font)
         {
             Name = Font.Name;

--- a/EPPlus/Style/ExcelTextFont.cs
+++ b/EPPlus/Style/ExcelTextFont.cs
@@ -293,6 +293,9 @@ namespace OfficeOpenXml.Style
         /// Set the font style from a font object
         /// </summary>
         /// <param name="Font"></param>
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void SetFromFont(Font Font)
         {
             LatinFont = Font.Name;

--- a/EPPlus/Style/XmlAccess/ExcelFontXml.cs
+++ b/EPPlus/Style/XmlAccess/ExcelFontXml.cs
@@ -269,6 +269,9 @@ namespace OfficeOpenXml.Style.XmlAccess
                 _verticalAlign=value;
             }
         }
+#if NET6_0_OR_GREATER
+        [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
         public void SetFromFont(System.Drawing.Font Font)
         {
             Name=Font.Name;

--- a/EPPlusTest/CompoundDoc.cs
+++ b/EPPlusTest/CompoundDoc.cs
@@ -245,7 +245,9 @@ namespace EPPlusTest
                 // ws.Calculate();
 
                 Console.WriteLine("{0:HH.mm.ss}\tAutofit columns and lock and format cells...", DateTime.Now);
+#if !NoDrawing
                 ws.Cells[Rows - 100, 1, Rows, 5].AutoFitColumns(5);   //Auto fit using the last 100 rows with minimum width 5
+#endif
                 ws.Column(5).Width = 15;                            //We need to set the width for column F manually since the end sum formula is the widest cell in the column (EPPlus don't calculate any forumlas, so no output text is avalible). 
 
                 //Now we set the sheetprotection and a password.

--- a/EPPlusTest/DTS_FailingTests.cs
+++ b/EPPlusTest/DTS_FailingTests.cs
@@ -11,7 +11,7 @@ namespace EPPlusTest
     [TestClass]
     public class DTS_FailingTests
     {
-
+#if !NoDrawing
         [TestMethod]
         public void DeleteWorksheetWithReferencedImage()
         {
@@ -45,5 +45,6 @@ namespace EPPlusTest
                 pck.Save();
             }
         }
+#endif
     }
 }

--- a/EPPlusTest/DrawingTest.cs
+++ b/EPPlusTest/DrawingTest.cs
@@ -13,6 +13,7 @@ using System.Reflection;
 
 namespace EPPlusTest
 {
+#if !NoDrawing
     /// <summary>
     /// Summary description for UnitTest1
     /// </summary>
@@ -966,4 +967,5 @@ namespace EPPlusTest
             //}
         }
     }
+#endif
 }

--- a/EPPlusTest/EPPlusTest.Core.csproj
+++ b/EPPlusTest/EPPlusTest.Core.csproj
@@ -50,4 +50,7 @@
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
+  <ItemGroup>
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+  </ItemGroup>
 </Project>

--- a/EPPlusTest/EPPlusTest.Core.csproj
+++ b/EPPlusTest/EPPlusTest.Core.csproj
@@ -13,10 +13,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net462;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0-windows;net462;net48;net8.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EPPlusTest/EPPlusTest.Core.csproj
+++ b/EPPlusTest/EPPlusTest.Core.csproj
@@ -13,10 +13,18 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'true'">
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0-windows;net462;net48;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net6.0;net8.0;net462;net48</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'"><!-- enable System.Drawing.Common on .NET 6 -->
+    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0' AND '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' != 'true'">
+    <DefineConstants>NoDrawing</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -48,9 +56,5 @@
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <RuntimeHostConfigurationOption Include="System.Drawing.EnableUnixSupport" Value="true" />
   </ItemGroup>
 </Project>

--- a/EPPlusTest/Issues.cs
+++ b/EPPlusTest/Issues.cs
@@ -80,6 +80,7 @@ namespace EPPlusTest
                 ws.Dispose();
             }
         }
+#if !NoDrawing
         [TestMethod]
         public void Issue15022()
         {
@@ -91,6 +92,7 @@ namespace EPPlusTest
                 ws.Cells.AutoFitColumns();
             }
         }
+#endif
         [TestMethod]
         public void Issue15056()
         {
@@ -307,7 +309,9 @@ namespace EPPlusTest
                 ws.Cells["D2:D3"].Style.Numberformat.Format = "(* #,##0.00);_(* (#,##0.00);_(* \"-\"??_);(@)";
 
                 ws.Cells["E2:E3"].Style.Numberformat.Format = "mm/dd/yyyy";
+#if !NoDrawing
                 ws.Cells.AutoFitColumns();
+#endif
                 Assert.AreNotEqual(ws.Cells[2, 5].Text, "");
             }
         }
@@ -465,6 +469,7 @@ namespace EPPlusTest
                 package.SaveAs(new FileInfo(@"C:\temp\bug\MyTemplate2.xlsx"));
             }
         }
+#if !NoDrawing
         [Ignore]
         [TestMethod]
         public void PictureIssue()
@@ -474,6 +479,7 @@ namespace EPPlusTest
             ws.Drawings.AddPicture("Test", new FileInfo(@"c:\temp\bug\2152228.jpg"));
             p.SaveAs(new FileInfo(@"c:\temp\bug\pic.xlsx"));
         }
+#endif
 
         [Ignore]
         [TestMethod]
@@ -839,7 +845,9 @@ namespace EPPlusTest
                     range.Style.Numberformat.Format = "mm-dd-yy";
                 }
 
+#if !NoDrawing
                 wsData.Cells.AutoFitColumns(0);
+#endif
                 EP.Save();
             }
         }
@@ -1636,7 +1644,9 @@ namespace EPPlusTest
                 ws.Cells["E1"].Value = "Cell value 5";
             }
             //ws.Cells.Style.VerticalAlignment = ExcelVerticalAlignment::Top; // Columns 4 and greater hidden
+#if !NoDrawing
             ws.Cells.AutoFitColumns(0);
+#endif
             ws.Cells.Style.VerticalAlignment = ExcelVerticalAlignment.Top; // 4.1.1.0 - exception, 4.0.4.0 - columns 4 and 5 hidden
             ws.Column(4).Hidden = true;
             ws.Column(5).Hidden = true; // span exception
@@ -1906,6 +1916,7 @@ namespace EPPlusTest
             }
         }
 
+#if !NoDrawing
         [TestMethod, Ignore]
         public void Issue100()
         {
@@ -1922,6 +1933,8 @@ namespace EPPlusTest
                 package.SaveAs(outputFile);
             }
         }
+#endif
+
         [TestMethod, Ignore]
         public void Issue99()
         {
@@ -2042,6 +2055,7 @@ namespace EPPlusTest
                 pck.SaveAs(new FileInfo($@"C:\temp\bug\issue181-saved.xlsx"));
             }
         }
+#if !NoDrawing
         [TestMethod, Ignore]
         public void Issue10()
         {
@@ -2064,6 +2078,7 @@ namespace EPPlusTest
                 pck.Save();
             }
         }
+#endif
         /// <summary>
         /// Creating a new ExcelPackage with an external stream should not dispose of 
         /// that external stream. That is the responsibility of the caller.
@@ -2247,7 +2262,9 @@ namespace EPPlusTest
             var ws = _pck.Workbook.Worksheets["Sheet1"];
             var d = ws.Drawings.AddShape("Shape1", eShapeStyle.Diamond);
             ws.Cells["A1"].Value = "tasetraser";
+#if !NoDrawing
             ws.Cells.AutoFitColumns();
+#endif
             SaveWorksheet("Font55-Saved.xlsx");
         }
         [TestMethod]
@@ -2428,6 +2445,7 @@ namespace EPPlusTest
                 Assert.AreEqual(new DateTime(2019, 3, 7).ToShortDateString(), ws.Cells["A1"].Text);
             }
         }
+#if !NoDrawing
         [TestMethod]
         public void Issue445()
         {
@@ -2436,6 +2454,7 @@ namespace EPPlusTest
             ws.Cells[1, 1].Value = new string('a', 50000);
             ws.Cells[1, 1].AutoFitColumns();
         }
+#endif
         [TestMethod]
         public void Issue460()
         {

--- a/EPPlusTest/WorkSheetTests.cs
+++ b/EPPlusTest/WorkSheetTests.cs
@@ -48,7 +48,9 @@ namespace EPPlusTest
             RichTextCells();
             TestComments();
             Hyperlink();
+#if !NoDrawing
             PictureURL();
+#endif
             CopyOverwrite();
             HideTest();
             VeryHideTest();
@@ -65,7 +67,9 @@ namespace EPPlusTest
             WorksheetCopy();
             DefaultColWidth();
             CopyTable();
+#if !NoDrawing
             AutoFitColumns();
+#endif
             CopyRange();
             CopyMergedRange();
             ValueError();
@@ -77,7 +81,9 @@ namespace EPPlusTest
             DefinedName();
             CreatePivotTable();
             AddChartSheet();
+#if !NoDrawing
             SetHeaderFooterImage();
+#endif
 
             SaveWorksheet("Worksheet.xlsx");
 
@@ -344,6 +350,7 @@ namespace EPPlusTest
             instream.Close();
         }
 
+#if !NoDrawing
         [Ignore]
         [TestMethod]
         public void ReadStreamWithTemplateWorkSheet()
@@ -379,6 +386,7 @@ namespace EPPlusTest
             }
             instream.Close();
         }
+#endif
         //[Ignore]
         //[TestMethod]
         public void ReadStreamSaveAsStream()
@@ -466,8 +474,10 @@ namespace EPPlusTest
 
             // add autofilter
             ws.Cells["U19:X24"].AutoFilter = true;
+#if !NoDrawing
             ExcelPicture pic = ws.Drawings.AddPicture("Pic1", Properties.Resources.Test1);
             pic.SetPosition(150, 140);
+#endif
 
             ws.Cells["A30"].Value = "Text orientation 45";
             ws.Cells["A30"].Style.TextRotation = 45;
@@ -1131,6 +1141,7 @@ namespace EPPlusTest
             ws.Cells["E2:E5"].CreateArrayFormula("FREQUENCY(B2:B18,C2:C5)");
             _pck.SaveAs(new FileInfo("c:\\temp\\arrayformula.xlsx"));
         }
+#if !NoDrawing
         //[Ignore]
         //[TestMethod]
         public void PictureURL()
@@ -1142,6 +1153,7 @@ namespace EPPlusTest
 
             ws.Drawings.AddPicture("Pic URI", Properties.Resources.Test1, hl);
         }
+#endif
         [TestMethod]
         public void PivotTableTest()
         {
@@ -1894,7 +1906,10 @@ namespace EPPlusTest
             using (ExcelRange r = ws.Cells["A1:F1"])
             {
                 r.Merge = true;
-                r.Style.Font.SetFromFont(new Font("Arial", 18, FontStyle.Italic));
+                //r.Style.Font.SetFromFont(new Font("Arial", 18, FontStyle.Italic));
+                r.Style.Font.Name = "Arial";
+                r.Style.Font.Size = 18;
+                r.Style.Font.Italic = true;
                 r.Style.Font.Color.SetColor(Color.DarkRed);
                 r.Style.HorizontalAlignment = OfficeOpenXml.Style.ExcelHorizontalAlignment.CenterContinuous;
                 //r.Style.Fill.PatternType = OfficeOpenXml.Style.ExcelFillStyle.Solid;
@@ -2254,6 +2269,7 @@ namespace EPPlusTest
 
             pck.Save();
         }
+#if !NoDrawing
         //[Ignore]
         [TestMethod]
         public void SetBackground()
@@ -2296,6 +2312,7 @@ namespace EPPlusTest
 
             _pck.Workbook.Worksheets.Copy(ws.Name, "Copied HeaderImage");
         }
+#endif
         //[Ignore]
         //[TestMethod]
         public void NamedStyles()
@@ -2313,8 +2330,10 @@ namespace EPPlusTest
             s.VerticalAlignment = ExcelVerticalAlignment.Center;
 
             var secondNamedStyle = _pck.Workbook.Styles.CreateNamedStyle("first", firstNamedStyle.Style).Style;
+            //secondNamedStyle.Font.SetFromFont(new Font("Arial Black", 8));
+            secondNamedStyle.Font.Name = "Arial Black";
+            secondNamedStyle.Font.Size = 8;
             secondNamedStyle.Font.Bold = true;
-            secondNamedStyle.Font.SetFromFont(new Font("Arial Black", 8));
             secondNamedStyle.Border.Bottom.Style = ExcelBorderStyle.Medium;
             secondNamedStyle.Border.Left.Style = ExcelBorderStyle.Medium;
 
@@ -2415,6 +2434,7 @@ namespace EPPlusTest
             //  n.CustomBuildin = true;
             pck.SaveAs(new FileInfo(@"c:\temp\style.xlsx"));
         }
+#if !NoDrawing
         //[Ignore]
         //[TestMethod]
         public void AutoFitColumns()
@@ -2432,6 +2452,7 @@ namespace EPPlusTest
 
             ws.Column(40).AutoFit();
         }
+#endif
         [TestMethod, Ignore]
         public void Moveissue()
         {
@@ -2903,6 +2924,7 @@ namespace EPPlusTest
             excelPackage.Save();
             var s = stream.ToArray();
         }
+#if !NoDrawing
         [TestMethod, Ignore]
         public void ColumnsTest()
         {
@@ -2925,6 +2947,7 @@ namespace EPPlusTest
             ws.Column(26).ColumnMax = ExcelPackage.MaxColumns;
             excelPackage.SaveAs(new FileInfo(@"c:\temp\autofit.xlsx"));
         }
+#endif
 
         [TestMethod]
         public void Comment()


### PR DESCRIPTION
Methods that reference the `Font` or `Image` class, along with the auto-size column methods, have been marked as follows for .NET 6 or later:

```cs
[System.Runtime.Versioning.SupportedOSPlatform("windows")]
```

For any text, the font can be set by setting the individual properties, so in general EPPlus-LGPL should be usable so long as you are not embedding images and do not auto-size columns.

Tests have been modified so that testing of affected methods are skipped on .NET 8 when run on Ubuntu, but run on other frameworks and/or when run on Windows.

The entire `ExcelPicture` class currently is marked with the above attribute.  With some little code, it is likely the scope of the attribute could be reduced.  This would prevent a couple instances where the warning was suppressed internally.

Changing image handling to use SkiaSharp is probably a viable choice, but not yet implemented.  Very likely a similar solution could be implemented to restore column auto-sizing functionality.